### PR TITLE
fix pandas future wanrning issue

### DIFF
--- a/dagsim/Graph.py
+++ b/dagsim/Graph.py
@@ -150,7 +150,7 @@ class Graph:
         for node in self.nodes:
             if node.parents is not None:
                 for parent in node.parents:
-                    matrix[node.name][parent.name] = 1
+                    matrix.loc[parent.name, node.name] = 1
         self.adj_mat = matrix
 
     def _update_topol_order(self):


### PR DESCRIPTION
It was throwing this warning:
.../python3.12/site-packages/dagsim/Graph.py:153): FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
A typical example is when you are setting values in a column of a DataFrame, like:

df["col"][row_indexer] = value

Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy

  matrix[node.name][parent.name] = 1